### PR TITLE
Added markerType option with values: outline, background, underline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 typings
 dist
 .DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [vscode-ext-color-highlight](https://github.com/naumovs/vscode-ext-color-highlight)
 
-This extension adds a colored border around the css/web colors found in your document
+This extension styles css/web colors found in your document.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
           "default": [ "javascript", "scss", "css", "sass", "less", "php", "xml", "html", "json" ],
           "title": "Autohighlight files with these languages",
           "type": "array"
+        },
+        "color-highlight.markerType": {
+          "default": "outline",
+          "title": "Highlight style, valid types: 'background', 'outline', 'underline'",
+          "type": "string"
         }
       }
     },

--- a/src/lib/color-highlight.js
+++ b/src/lib/color-highlight.js
@@ -3,11 +3,13 @@ const window = require('vscode').window;
 const Range = require('vscode').Range;
 
 const colorFinder = require('./color-finder');
+const getColorContrast = require('./dynamic-contrast');
 
 class ColorHighlight {
 
-  constructor (document) {
+  constructor (document, markerType) {
     this.document = document;
+    this.markerType = markerType;
 
     this.colors = {};
     this.decorations = [];
@@ -53,14 +55,28 @@ class ColorHighlight {
       }).catch(error => console.log(error));
   }
 
-  getColorDecoration (color) {
+  getColorDecoration(color) {
+    let rules = {
+      overviewRulerColor: color
+    };
+
+    switch (this.markerType) {
+      case 'background':
+        rules.backgroundColor = color;
+        rules.color = getColorContrast(color) === 'dark' ? '#111' : '#fff';
+        break;
+      case 'underline':
+        rules.color = 'inherit; border-bottom:solid 2px ' + color;
+        break;
+      default:  // outline
+        rules.borderColor = color;
+        rules.borderStyle = 'solid';
+        rules.borderWidth = '3px';
+        break;
+    }
+
     if (!this.colors[color]) {
-      this.colors[color] = window.createTextEditorDecorationType({
-        overviewRulerColor: color,
-        borderColor: color,
-        borderStyle: 'solid',
-        borderWidth: '3px'
-      });
+      this.colors[color] = window.createTextEditorDecorationType(rules);
     }
 
     return this.colors[color];

--- a/src/lib/dynamic-contrast.js
+++ b/src/lib/dynamic-contrast.js
@@ -1,0 +1,48 @@
+// getColorContrast
+//     Return suggested contrast color (dark or light) for the color (hex/rgba) given.
+//     Takes advantage of YIQ: https://en.wikipedia.org/wiki/YIQ
+//         dark = background is light, use dark colors for text, images, etc..
+//         light = background is dark, use light colors for text, images, etc..
+//     Inspired by: http://24ways.org/2010/calculating-color-contrast/
+//
+// @param color string A valid hex or rgb value, examples:
+//                         #000, #000000, 000, 000000
+//                         rgb(255, 255, 255), rgba(255, 255, 255),
+//                         rgba(255, 255, 255, 1)
+// @return      string dark|light
+function getColorContrast(color) {
+    if(color === undefined || color === "") {
+        return null;
+    }
+    var rgbExp = /^rgba?[\s+]?\(\s*(([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]))\s*,\s*([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*,\s*([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*,?(?:\s*([\d.]+))?\s*\)?\s*/im,
+        hexExp = /^(?:#)|([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/igm,
+        rgb    = color.match(rgbExp),
+        hex    = color.match(hexExp),
+        r,
+        g,
+        b,
+        yiq;
+    if (rgb) {
+        r = parseInt(rgb[1], 10);
+        g = parseInt(rgb[2], 10);
+        b = parseInt(rgb[3], 10);
+    } else if (hex)  {
+        if (hex.length > 1) {
+            hex = hex[1];
+        } else {
+            hex = hex[0];
+        }
+        if (hex.length == 3) {
+            hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+        }
+        r = parseInt(hex.substr(0,2),16);
+        g = parseInt(hex.substr(2,2),16);
+        b = parseInt(hex.substr(4,2),16);
+    } else {
+        return null;
+    }
+    yiq = ((r*299)+(g*587)+(b*114))/1000;
+    return (yiq >= 128) ? 'dark' : 'light';
+}
+
+module.exports = getColorContrast;

--- a/src/main.js
+++ b/src/main.js
@@ -20,14 +20,14 @@ function activate (ctx) {
 
   const textEditorCommand = vscode.commands.registerTextEditorCommand('extension.colorHighlight', enable);
 
-  vscode.window.onDidChangeActiveTextEditor(editor => enable(editor), null, context.subscriptions);
+  vscode.window.onDidChangeActiveTextEditor(editor => enable(editor, config.markerType), null, context.subscriptions);
   vscode.workspace.onDidCloseTextDocument(disable, null, context.subscriptions);
 
   vscode.workspace.onDidChangeTextDocument(event => {
     const activeTextEditor = vscode.window.activeTextEditor;
 
     if (activeTextEditor && event && event.document === activeTextEditor.document) {
-      enable(activeTextEditor);
+      enable(activeTextEditor, config.markerType);
     }
   }, null, context.subscriptions);
 
@@ -37,12 +37,12 @@ function activate (ctx) {
   context.subscriptions.push(textEditorCommand);
 }
 
-function enable (editor, edit) {
+function enable (editor, markerType, edit) {
   if (!editor) {
     return Promise.resolve(null);
   }
 
-  return getInstanceForDocument(editor.document, !!edit)
+  return getInstanceForDocument(editor.document, markerType, !!edit)
     .then(instance => instance && instance.triggerUpdate());
 }
 
@@ -75,7 +75,7 @@ module.exports = {
   deactivate
 };
 
-function getInstanceForDocument (document, force) {
+function getInstanceForDocument(document, markerType, force) {
   const fileName = context && document && document.fileName;
 
   if (!fileName) {
@@ -87,7 +87,7 @@ function getInstanceForDocument (document, force) {
   }
 
   if ((filterDoc(document) || force) && (!state[fileName] || state[fileName].disposed))  {
-    state[fileName] = new ColorHighlight(document);
+    state[fileName] = new ColorHighlight(document, markerType);
   }
 
   return Promise.resolve(state[fileName]);


### PR DESCRIPTION
`outline` is the default, I also considered changing `overviewRulerColor` to a separate option to match [pigments](https://atom.io/packages/pigments) and changing the outline border thickness to 2px instead of 3px, but I'll leave that for you to decide. #3 